### PR TITLE
Hack/mavlink set speed

### DIFF
--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1414,11 +1414,11 @@ void GCS_MAVLINK_Plane::handle_message(const mavlink_message_t &msg)
             Vector3f vel_vector_cms;  // cm/s
             if (!vel_ignore) {
                 vel_vector = Vector3f{packet.vx, packet.vy, -packet.vz};
-                // TODO: sanity check velocity 
+                // TODO: sanity check velocity? 
 
-                //vel_vector *= 100;  // m/s -> cm/s
                 vel_vector_cms = vel_vector * 100;
-                // rotate to body-frame if necessary
+
+                // rotate to body-frame if necessary (not supported)
                 if (packet.coordinate_frame != MAV_FRAME_LOCAL_NED) {
                     gcs().send_text(
                         MAV_SEVERITY_INFO,
@@ -1427,35 +1427,12 @@ void GCS_MAVLINK_Plane::handle_message(const mavlink_message_t &msg)
                 }
             }
 
-            // set VTOL mode
-            // plane.quadplane.handle_do_vtol_transition(MAV_VTOL_STATE_MC);
-
             // set velocities
             gcs().send_text(
                 MAV_SEVERITY_INFO,
                 "Setting NED velocity to N=%.1f E=%.1f D=%.1f",
                 vel_vector.x, vel_vector.y, vel_vector.z
             );
-            /* 
-            Vector2f target_accel;
-            Vector2f target_vel = vel_vector_cms.xy();
-            float target_speed_ms = vel_vector.xy().length();
-            plane.quadplane.pos_control->input_vel_accel_xy(
-                target_vel, target_accel, false
-            );
-            Vector2p target_pos;
-            plane.quadplane.pos_control->set_pos_vel_accel_xy(
-                target_pos, target_accel, target_vel 
-            );
-            plane.quadplane.poscontrol.target_speed = target_speed_ms;
-            plane.quadplane.poscontrol.target_vel_cms = vel_vector_cms; 
-            plane.quadplane.poscontrol.velocity_match = vel_vector.xy();
-            plane.quadplane.poscontrol.last_velocity_match_ms = AP_HAL::millis();
-            plane.quadplane.pos_control->stop_pos_xy_stabilisation();
-            plane.quadplane.run_xy_controller();
-            // plane.quadplane.pos_control->update_xy_controller();
-            */
-
             
             plane.quadplane.poscontrol.velocity_match = vel_vector.xy();
             plane.quadplane.poscontrol.last_velocity_match_ms = AP_HAL::millis();

--- a/ArduPlane/GCS_Mavlink.cpp
+++ b/ArduPlane/GCS_Mavlink.cpp
@@ -1237,6 +1237,29 @@ void GCS_MAVLINK_Plane::handle_manual_control_axes(const mavlink_manual_control_
 
 void GCS_MAVLINK_Plane::handle_message(const mavlink_message_t &msg)
 {
+    // for mavlink SET_POSITION_TARGET messages
+    constexpr uint32_t MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE =
+        POSITION_TARGET_TYPEMASK_X_IGNORE |
+        POSITION_TARGET_TYPEMASK_Y_IGNORE |
+        POSITION_TARGET_TYPEMASK_Z_IGNORE;
+
+    constexpr uint32_t MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE =
+        POSITION_TARGET_TYPEMASK_VX_IGNORE |
+        POSITION_TARGET_TYPEMASK_VY_IGNORE |
+        POSITION_TARGET_TYPEMASK_VZ_IGNORE;
+
+    constexpr uint32_t MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE =
+        POSITION_TARGET_TYPEMASK_AX_IGNORE |
+        POSITION_TARGET_TYPEMASK_AY_IGNORE |
+        POSITION_TARGET_TYPEMASK_AZ_IGNORE;
+
+    constexpr uint32_t MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE =
+        POSITION_TARGET_TYPEMASK_YAW_IGNORE;
+    constexpr uint32_t MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE =
+        POSITION_TARGET_TYPEMASK_YAW_RATE_IGNORE;
+    constexpr uint32_t MAVLINK_SET_POS_TYPE_MASK_FORCE_SET =
+        POSITION_TARGET_TYPEMASK_FORCE_SET;
+
     switch (msg.msgid) {
 
     case MAVLINK_MSG_ID_RADIO:
@@ -1339,15 +1362,107 @@ void GCS_MAVLINK_Plane::handle_message(const mavlink_message_t &msg)
         }
 
         // only local moves for now
-        if (packet.coordinate_frame != MAV_FRAME_LOCAL_OFFSET_NED) {
-            break;
-        }
+        if (packet.coordinate_frame == MAV_FRAME_LOCAL_OFFSET_NED) {
+            // just do altitude for now
+            plane.next_WP_loc.alt += -packet.z*100.0;
+            gcs().send_text(MAV_SEVERITY_INFO, "Change alt to %.1f",
+                            (double)((plane.next_WP_loc.alt - plane.home.alt)*0.01));
+            
+        } else if (packet.coordinate_frame == MAV_FRAME_LOCAL_NED) {
+            // only if Q_GUIDED_MODE is enabled
+            if (!plane.quadplane.guided_mode_enabled()) {
+                gcs().send_text(
+                    MAV_SEVERITY_INFO,
+                    "Set position called but Q_GUIDED_MODE is not enabled"
+                );
+                break;
+            }
 
-        // just do altitude for now
-        plane.next_WP_loc.alt += -packet.z*100.0;
-        gcs().send_text(MAV_SEVERITY_INFO, "Change alt to %.1f",
-                        (double)((plane.next_WP_loc.alt - plane.home.alt)*0.01));
-        
+            // make sure in VTOL mode
+            if (!plane.quadplane.in_vtol_mode()) {
+                gcs().send_text(
+                    MAV_SEVERITY_INFO,
+                    "Set position called but not in vtol mode"
+                );
+                break;
+            }
+
+            bool pos_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_POS_IGNORE;
+            bool vel_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_VEL_IGNORE;
+            bool acc_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_ACC_IGNORE;
+            bool yaw_ignore      = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_IGNORE;
+            bool yaw_rate_ignore = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_YAW_RATE_IGNORE;
+            bool force_set       = packet.type_mask & MAVLINK_SET_POS_TYPE_MASK_FORCE_SET;
+            if (!pos_ignore || vel_ignore || !acc_ignore || !yaw_ignore
+                || !yaw_rate_ignore || !force_set) {
+                gcs().send_text(
+                    MAV_SEVERITY_INFO,
+                    "Set position called with other than velocity ignore"
+                );
+                gcs().send_text(
+                    MAV_SEVERITY_INFO,
+                    "mask=%d p=%d v=%d acc=%d yi=%d yri=%d fs=%d",
+                    packet.type_mask,
+                    pos_ignore, vel_ignore, acc_ignore, yaw_ignore,
+                    yaw_rate_ignore, force_set
+                );
+                break;
+            }
+
+            // prepare velocity
+            Vector3f vel_vector;      // m/s
+            Vector3f vel_vector_cms;  // cm/s
+            if (!vel_ignore) {
+                vel_vector = Vector3f{packet.vx, packet.vy, -packet.vz};
+                // TODO: sanity check velocity 
+
+                //vel_vector *= 100;  // m/s -> cm/s
+                vel_vector_cms = vel_vector * 100;
+                // rotate to body-frame if necessary
+                if (packet.coordinate_frame != MAV_FRAME_LOCAL_NED) {
+                    gcs().send_text(
+                        MAV_SEVERITY_INFO,
+                        "Set position called with other than MAV_FRAME_LOCAL_NED" 
+                    );
+                }
+            }
+
+            // set VTOL mode
+            // plane.quadplane.handle_do_vtol_transition(MAV_VTOL_STATE_MC);
+
+            // set velocities
+            gcs().send_text(
+                MAV_SEVERITY_INFO,
+                "Setting NED velocity to N=%.1f E=%.1f D=%.1f",
+                vel_vector.x, vel_vector.y, vel_vector.z
+            );
+            /* 
+            Vector2f target_accel;
+            Vector2f target_vel = vel_vector_cms.xy();
+            float target_speed_ms = vel_vector.xy().length();
+            plane.quadplane.pos_control->input_vel_accel_xy(
+                target_vel, target_accel, false
+            );
+            Vector2p target_pos;
+            plane.quadplane.pos_control->set_pos_vel_accel_xy(
+                target_pos, target_accel, target_vel 
+            );
+            plane.quadplane.poscontrol.target_speed = target_speed_ms;
+            plane.quadplane.poscontrol.target_vel_cms = vel_vector_cms; 
+            plane.quadplane.poscontrol.velocity_match = vel_vector.xy();
+            plane.quadplane.poscontrol.last_velocity_match_ms = AP_HAL::millis();
+            plane.quadplane.pos_control->stop_pos_xy_stabilisation();
+            plane.quadplane.run_xy_controller();
+            // plane.quadplane.pos_control->update_xy_controller();
+            */
+
+            
+            plane.quadplane.poscontrol.velocity_match = vel_vector.xy();
+            plane.quadplane.poscontrol.last_velocity_match_ms = AP_HAL::millis();
+            plane.quadplane.poscontrol.override_descent_rate = vel_vector.z;
+            plane.quadplane.poscontrol.last_override_descent_ms = AP_HAL::millis();
+             
+        }
         break;
     }
 

--- a/ArduPlane/mode.h
+++ b/ArduPlane/mode.h
@@ -295,6 +295,8 @@ public:
 
     void update_target_altitude() override;
 
+    void run() override;
+
 protected:
 
     bool _enter() override;

--- a/ArduPlane/mode_guided.cpp
+++ b/ArduPlane/mode_guided.cpp
@@ -146,3 +146,31 @@ void ModeGuided::update_target_altitude()
         Mode::update_target_altitude();
     }
 }
+
+// run guided controller
+void ModeGuided::run()
+{
+    const uint32_t now = AP_HAL::millis();
+    const uint32_t timeout_ms = 1000;
+    const uint32_t last_vel_set_ms = quadplane.poscontrol.last_velocity_match_ms;
+
+    // allow for velocity override as well
+    if (last_vel_set_ms != 0 && now - last_vel_set_ms < timeout_ms) {
+        // we have an active landing velocity override
+        Vector2f target_accel;
+        Vector2f target_speed_xy_cms{
+            quadplane.poscontrol.velocity_match.x*100, 
+            quadplane.poscontrol.velocity_match.y*100
+        };
+        pos_control->input_vel_accel_xy(target_speed_xy_cms, target_accel);
+        Vector2p target_pos;
+        pos_control->set_pos_vel_accel_xy(
+                target_pos, target_accel, target_speed_xy_cms 
+        );
+        pos_control->stop_pos_xy_stabilisation();
+        quadplane.run_xy_controller();
+        poscontrol.last_velocity_match_ms = 0;
+    } else {
+        Mode::run();
+    }
+}


### PR DESCRIPTION
Attempted hack at adding support for setting velocities using MavLink `SET_POSITION_TARGET_LOCAL_NED` message on QuadPlanes. (Related to [this issue](https://github.com/ArduPilot/ardupilot/issues/19858).) 

**Approach**
  * updated `ArduPlane/GCS_Mavlink.cpp` file to parse the message (largely based on the [copter code](https://github.com/ryochiji/ardupilot/blob/Plane-4.5/ArduCopter/GCS_Mavlink.cpp#L1277))
  *  add a `run()` method to `ArduPlane/mode_guided.cpp` (based largely on `ModeQLoiter::run()` and other bits of code)

**Testing**
Tested on SITL by sending MavLink messages with `dronekit`.  The [test script](https://gist.github.com/ryochiji/e41d3061b84e89d33350ace31ad77130) tries to fly the drone in a "box" by flying in each cardinal direction in turn. Verified the script will fly a Copter as expected.

**Issues**
 * Speed drops to almost 0 after ~3 seconds and then drone seems to either continue in straight line or meander
 *  North/South seems off by 20-30 degrees or more (see groundtrack in pic below):
 
<img width="1233" alt="Screenshot 2025-01-28 at 10 03 36 AM" src="https://github.com/user-attachments/assets/38ddbbb3-7fc0-4812-9cb9-b82791948f3c" />
